### PR TITLE
Feature/keep trick stats during setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:es": "eslint --ignore-path .gitignore \"src/**/*.{ts,tsx,js}\"",
     "lint:style": "stylelint --ignore-path .gitignore \"src/**/*.{ts,tsx,js}\"",
     "server:watch": "parcel src/server.ts --target node -d dist/server",
-    "server:serve": "nodemon dist/server/server.js -w dist",
+    "server:serve": "nodemon dist/server/server.js -w dist/server",
     "dev-server": "concurrently --kill-others -n \"parcel,nodemon\" -p \"{time}-{name}\" -t \"HH:mm:ss\" \"yarn run server:watch\" \"yarn run server:serve\""
   },
   "keywords": [

--- a/src/game/phases/setup.test.ts
+++ b/src/game/phases/setup.test.ts
@@ -1,7 +1,7 @@
 import range from "lodash/range";
 import { generateCtx } from "../../test/utils/ctx";
 import { generateDefaultWizardState, WizardState } from "../WizardState";
-import { shuffle, handout } from "./setup";
+import { shuffleMove, handoutMove } from "./setup";
 import { Suit, Rank } from "../entities/cards";
 import { Phase } from "./phase";
 
@@ -10,7 +10,7 @@ describe("shuffle", () => {
     const ctx = generateCtx();
     const g = generateDefaultWizardState(ctx);
     const originalDeck = g.round!.deck;
-    shuffle(g);
+    shuffleMove(g);
     expect(g.round!.deck).not.toBe(originalDeck);
   });
 });
@@ -20,7 +20,7 @@ describe("handout", () => {
     const ctx = generateCtx();
     const g = generateDefaultWizardState(ctx);
 
-    handout(g, ctx);
+    handoutMove(g, ctx);
     g.round!.hands.forEach((hand) => {
       expect(hand).toBeInstanceOf(Array);
       expect(hand.length).toBe(g.numCards);
@@ -34,7 +34,7 @@ describe("handout", () => {
     const expectedTrump = g.round!.deck[
       g.round!.deck.length - g.numCards * ctx.numPlayers - 1
     ];
-    handout(g, ctx);
+    handoutMove(g, ctx);
     expect(g.round!.trump.card).toBe(expectedTrump);
   });
 
@@ -62,7 +62,7 @@ describe("handout", () => {
       const g = generateDefaultWizardState(ctx);
       const trumpIndex = g.round!.deck.length - g.numCards * ctx.numPlayers - 1;
       g.round!.deck[trumpIndex] = { suit, rank };
-      handout(g, ctx);
+      handoutMove(g, ctx);
       expect(g.round!.trump.suit).toBe(suit);
     });
   });
@@ -73,7 +73,7 @@ describe("handout", () => {
     const trumpIndex = g.round!.deck.length - g.numCards * ctx.numPlayers - 1;
 
     g.round!.deck[trumpIndex] = { suit: Suit.Blue, rank: Rank.Z };
-    handout(g, ctx);
+    handoutMove(g, ctx);
     expect(g.round!.trump.suit).toBeUndefined();
   });
 
@@ -84,7 +84,7 @@ describe("handout", () => {
 
     g.round!.deck[trumpIndex] = { suit: Suit.Blue, rank: Rank.Z };
     ctx.events!.setPhase = jest.fn();
-    handout(g, ctx);
+    handoutMove(g, ctx);
     expect(ctx.events!.setPhase).toBeCalledWith(Phase.SelectingTrump);
   });
 
@@ -94,14 +94,14 @@ describe("handout", () => {
     const trumpIndex = g.round!.deck.length - g.numCards * ctx.numPlayers - 1;
 
     g.round!.deck[trumpIndex] = { suit: Suit.Yellow, rank: Rank.N };
-    handout(g, ctx);
+    handoutMove(g, ctx);
     expect(g.round!.trump.suit).toBeNull();
   });
 
   test("sets trumpCard and trumpSuit to null in final round", () => {
     const ctx = generateCtx({ numPlayers: 4 });
     const g = generateDefaultWizardState(ctx, { numCards: 15 });
-    handout(g, ctx);
+    handoutMove(g, ctx);
     expect(g.round!.trump.card).toBeNull();
     expect(g.round!.trump.suit).toBeNull();
   });
@@ -110,7 +110,7 @@ describe("handout", () => {
     const ctx = generateCtx();
     const g = generateDefaultWizardState(ctx);
     const originalLength = g.round!.deck.length;
-    handout(g, ctx);
+    handoutMove(g, ctx);
     expect(g.round!.deck.length).toBe(
       originalLength - ctx.numPlayers * g.numCards - 1
     );
@@ -125,7 +125,7 @@ describe("handout", () => {
         g.round!.deck[g.round!.deck.length - 1 - ctx.numPlayers * cardI]
     );
 
-    handout(g, ctx);
+    handoutMove(g, ctx);
 
     expect(g.round!.hands[1]).toEqual(cardsPlayer1);
   });
@@ -139,7 +139,7 @@ describe("handout", () => {
       (_, index) => g.round!.deck[g.round!.deck.length - 1 - index]
     );
 
-    handout(g, ctx);
+    handoutMove(g, ctx);
 
     playerOrder.forEach((player, i) => {
       expect(g.round!.hands[player][0]).toBe(expectedFirstCardByPlayer[i]);
@@ -152,7 +152,7 @@ describe("handout", () => {
     const mockEndPhase = jest.fn();
     ctx.events!.endPhase = mockEndPhase;
     ctx.events!.setPhase = mockEndPhase;
-    handout(g, ctx);
+    handoutMove(g, ctx);
 
     expect(mockEndPhase).toBeCalled();
   });

--- a/src/game/phases/setup.ts
+++ b/src/game/phases/setup.ts
@@ -14,14 +14,12 @@ import { Phase } from "./phase";
 import { onBeginTurn } from "../turn";
 import { NumPlayers, PlayerID } from "../entities/players";
 
-export function shuffle(wizardState: WizardState): void {
-  setupRound(wizardState);
+export function shuffleMove(wizardState: WizardState): void {
   // shuffle deck
   wizardState.round!.deck = shuffleUtil(wizardState.round!.deck);
 }
 
-export function handout(wizardState: WizardState, ctx: Ctx): void {
-  setupRound(wizardState);
+export function handoutMove(wizardState: WizardState, ctx: Ctx): void {
   const { round, numCards, numPlayers, currentPlayer } = wizardState;
   if (!isSetRound(round)) {
     throw new Error("round is not set");
@@ -92,6 +90,16 @@ function first(g: WizardState, ctx: Ctx): number {
   return ctx.playOrder.findIndex(
     (playerID) => playerID === g.dealer.toString()
   );
+}
+
+function shuffle(wizardState: WizardState): void {
+  setupRound(wizardState);
+  shuffleMove(wizardState);
+}
+
+function handout(wizardState: WizardState, ctx: Ctx): void {
+  setupRound(wizardState);
+  handoutMove(wizardState, ctx);
 }
 
 export const setup: PhaseConfig = {

--- a/src/game/phases/setup.ts
+++ b/src/game/phases/setup.ts
@@ -15,20 +15,17 @@ import { onBeginTurn } from "../turn";
 import { NumPlayers, PlayerID } from "../entities/players";
 
 export function shuffle(wizardState: WizardState): void {
-  // delete deprecated trick
-  wizardState.trick = null;
+  setupRound(wizardState);
   // shuffle deck
   wizardState.round!.deck = shuffleUtil(wizardState.round!.deck);
 }
 
-export function handout(g: WizardState, ctx: Ctx): void {
-  const { round, numCards, numPlayers, currentPlayer } = g;
+export function handout(wizardState: WizardState, ctx: Ctx): void {
+  setupRound(wizardState);
+  const { round, numCards, numPlayers, currentPlayer } = wizardState;
   if (!isSetRound(round)) {
     throw new Error("round is not set");
   }
-
-  // delete deprecated trick
-  g.trick = null;
 
   const players = playersRound(
     (currentPlayer + 1) % numPlayers,
@@ -72,9 +69,16 @@ export function handout(g: WizardState, ctx: Ctx): void {
   }
 }
 
+function setupRound(wizardState: WizardState): void {
+  // setup (or reset) round
+  if (!wizardState.round || wizardState.trick) {
+    wizardState.round = generateBlankRoundState(wizardState.numPlayers);
+  }
+  // reset trick
+  wizardState.trick = null;
+}
+
 function onBegin(g: WizardState): void {
-  // reset round
-  g.round = generateBlankRoundState(g.numPlayers);
   // set dealer
   if (!g.dealer) {
     // draw a dealer at the start of game


### PR DESCRIPTION
resolves #72 

Changes:

- nodemon script fix watch folder
- move reset of round state from begin of setup phase to begin of the shuffle and handout moves to keep the old bidding stats