### PR TITLE
do not set the previous trick's lead card to new leader calc playable

### DIFF
--- a/src/game/phases/playing.ts
+++ b/src/game/phases/playing.ts
@@ -27,6 +27,10 @@ export function play(
   if (!isSetRound(round)) {
     throw new Error("round is not set");
   }
+  // as first player, init trick
+  if (!g.trick || g.trick.isComplete) {
+    g.trick = generateBlankTrickState();
+  }
 
   const hand = round.hands[Number.parseInt(ctx.currentPlayer, 10)];
   if (cardIndex < 0 || cardIndex >= hand.length) {
@@ -37,10 +41,6 @@ export function play(
     return INVALID_MOVE;
   }
 
-  // as first player, init trick
-  if (!g.trick || g.trick.isComplete) {
-    g.trick = generateBlankTrickState();
-  }
   const { trick } = g;
   if (!isSetTrick(trick)) {
     throw new Error("trick is not set");

--- a/src/ui/player/Player.tsx
+++ b/src/ui/player/Player.tsx
@@ -32,7 +32,7 @@ export const Player: React.FC<PlayerProps> = ({ playerID }) => {
                 cards={round.hands[clientID]}
                 isInteractive={isTurn && phase === Phase.Playing}
                 onClickCard={(i) => play(i)}
-                lead={trick?.lead}
+                lead={trick?.isComplete ? undefined : trick?.lead}
               />
             ) : (
               <OpponentHand numCards={round.hands[playerID].length} />


### PR DESCRIPTION
fixes #76 

- the new trick leader is not influenced by the previous trick's lead suit when picking a lead card