### PR TITLE
prevent random dealer selection if previous dealer had id 0 (=falsy)

### DIFF
--- a/src/game/WizardState.ts
+++ b/src/game/WizardState.ts
@@ -124,7 +124,7 @@ export const generateDefaultWizardState = (
     trickOptions !== null ? generateBlankTrickState(trickOptions) : null;
   const defaultValues = {
     numCards: 1,
-    dealer: 0 as PlayerID,
+    dealer: -1 as PlayerID,
     scorePad: [],
     numPlayers,
     currentPlayer: Number.parseInt(ctx.currentPlayer, 10) as PlayerID,

--- a/src/game/phases/setup.ts
+++ b/src/game/phases/setup.ts
@@ -78,7 +78,7 @@ function setupRound(wizardState: WizardState): void {
 
 function onBegin(g: WizardState): void {
   // set dealer
-  if (!g.dealer) {
+  if (Number.isNaN(g.dealer)) {
     // draw a dealer at the start of game
     g.dealer = random(0, g.numPlayers - 1) as PlayerID;
   } else {

--- a/src/game/phases/setup.ts
+++ b/src/game/phases/setup.ts
@@ -78,7 +78,7 @@ function setupRound(wizardState: WizardState): void {
 
 function onBegin(g: WizardState): void {
   // set dealer
-  if (Number.isNaN(g.dealer)) {
+  if (!(g.dealer >= 0)) {
     // draw a dealer at the start of game
     g.dealer = random(0, g.numPlayers - 1) as PlayerID;
   } else {

--- a/src/game/phases/setup.ts
+++ b/src/game/phases/setup.ts
@@ -78,11 +78,11 @@ function setupRound(wizardState: WizardState): void {
 
 function onBegin(g: WizardState): void {
   // set dealer
-  if (!(g.dealer >= 0)) {
+  if (g.dealer >= 0) {
+    g.dealer = ((g.dealer + 1) % g.numPlayers) as PlayerID;
+  } else {
     // draw a dealer at the start of game
     g.dealer = random(0, g.numPlayers - 1) as PlayerID;
-  } else {
-    g.dealer = ((g.dealer + 1) % g.numPlayers) as PlayerID;
   }
 }
 


### PR DESCRIPTION
fixes #77 

Verwendet (~einen `isNaN` Check~) einen `g.dealer >= 0` Check anstatt einfachem `!g.dealer` um zwischen Spielanfang und während des Spiels zu unterscheiden, da letzteres auch bei einer ID mit dem Wert 0 zu einer Zufallswahl des Dealers führt.
