### PR TITLE
Feature/trick table improvements

### DIFF
--- a/src/game/WizardState.ts
+++ b/src/game/WizardState.ts
@@ -5,6 +5,7 @@ import { NumPlayers, PlayerID } from "./entities/players";
 import { Phase } from "./phases/phase";
 import { ScorePad } from "./entities/score";
 import { Card, Suit } from "./entities/cards";
+import { OptionalTrickCard } from "./entities/trick";
 
 /**
  * Describes the Wizard game state used in the g object.
@@ -33,7 +34,7 @@ export interface WizardState {
  * @interface WizardTrickState
  */
 export interface WizardTrickState {
-  cards: [Card, PlayerID][];
+  cards: OptionalTrickCard[];
   lead?: Card;
   isComplete?: boolean;
 }

--- a/src/game/WizardState.ts
+++ b/src/game/WizardState.ts
@@ -64,7 +64,7 @@ export interface WizardRoundState {
  * @interface Trump
  */
 export interface Trump {
-  card: Card | null;
+  card: Card | null | undefined;
   suit?: Suit | null;
 }
 

--- a/src/game/entities/cards.utils.test.ts
+++ b/src/game/entities/cards.utils.test.ts
@@ -8,6 +8,14 @@ import {
 } from "./cards.utils";
 import { PlayerID } from "./players";
 import { Rank, allSuits, Card, Suit } from "./cards";
+import { TrickCard } from "./trick";
+
+function tc(suit: Suit, rank: Rank, player: PlayerID): TrickCard {
+  return {
+    card: { suit, rank },
+    player,
+  };
+}
 
 describe("generateCardDeck", () => {
   test("contains 60 cards", () => {
@@ -176,8 +184,14 @@ describe("cardBeatsOther", () => {
 });
 
 describe("getTrickWinner", () => {
+  const B = Suit.Blue;
+  const G = Suit.Green;
+  const R = Suit.Red;
+  const Y = Suit.Yellow;
+  const { N, Z } = Rank;
+
   interface TestData {
-    cards: [Card, PlayerID][];
+    cards: TrickCard[];
     trumpSuit: Suit;
     winnerIndex: number;
   }
@@ -185,36 +199,36 @@ describe("getTrickWinner", () => {
     const testData: TestData[] = [
       {
         cards: [
-          [Card(Suit.Blue, Rank.Z), 1],
-          [Card(Suit.Red, 13), 2],
-          [Card(Suit.Yellow, 8), 0],
+          tc(B, Z, 1), // [Card(Suit.Blue, Rank.Z), 1],
+          tc(R, 13, 2), // [Card(Suit.Red, 13), 2],
+          tc(Y, 8, 0), // [Card(Suit.Yellow, 8), 0],
         ],
         trumpSuit: Suit.Yellow,
         winnerIndex: 0,
       },
       {
         cards: [
-          [Card(Suit.Red, 13), 0],
-          [Card(Suit.Yellow, 8), 1],
-          [Card(Suit.Blue, Rank.Z), 2],
+          tc(R, 13, 0), // [Card(Suit.Red, 13), 0],
+          tc(Y, 8, 1), // [Card(Suit.Yellow, 8), 1],
+          tc(B, Z, 2), // [Card(Suit.Blue, Rank.Z), 2],
         ],
         trumpSuit: Suit.Yellow,
         winnerIndex: 2,
       },
       {
         cards: [
-          [Card(Suit.Red, 13), 2],
-          [Card(Suit.Yellow, Rank.Z), 0],
-          [Card(Suit.Blue, Rank.Z), 1],
+          tc(R, 13, 2), // [Card(Suit.Red, 13), 2],
+          tc(Y, Z, 0), // [Card(Suit.Yellow, Rank.Z), 0],
+          tc(B, Z, 1), // [Card(Suit.Blue, Rank.Z), 1],
         ],
         trumpSuit: Suit.Red,
         winnerIndex: 1,
       },
       {
         cards: [
-          [Card(Suit.Red, Rank.Z), 1],
-          [Card(Suit.Yellow, Rank.Z), 2],
-          [Card(Suit.Blue, Rank.Z), 0],
+          tc(R, Z, 1), // [Card(Suit.Red, Rank.Z), 1],
+          tc(Y, Z, 2), // [Card(Suit.Yellow, Rank.Z), 2],
+          tc(B, Z, 0), // [Card(Suit.Blue, Rank.Z), 0],
         ],
         trumpSuit: Suit.Green,
         winnerIndex: 0,
@@ -230,18 +244,18 @@ describe("getTrickWinner", () => {
     const data: TestData[] = [
       {
         cards: [
-          [Card(Suit.Red, 7), 0],
-          [Card(Suit.Yellow, 13), 1],
-          [Card(Suit.Red, 9), 2],
+          tc(R, 7, 0), // [Card(Suit.Red, 7), 0],
+          tc(Y, 13, 1), // [Card(Suit.Yellow, 13), 1],
+          tc(R, 9, 2), // [Card(Suit.Red, 9), 2],
         ],
         trumpSuit: Suit.Green,
         winnerIndex: 2,
       },
       {
         cards: [
-          [Card(Suit.Blue, 3), 1],
-          [Card(Suit.Blue, 2), 2],
-          [Card(Suit.Red, 9), 0],
+          tc(B, 3, 1), // [Card(Suit.Blue, 3), 1],
+          tc(B, 2, 2), // [Card(Suit.Blue, 2), 2],
+          tc(R, 9, 0), // [Card(Suit.Red, 9), 0],
         ],
         trumpSuit: Suit.Green,
         winnerIndex: 0,
@@ -257,27 +271,27 @@ describe("getTrickWinner", () => {
     const data: TestData[] = [
       {
         cards: [
-          [Card(Suit.Red, 7), 2],
-          [Card(Suit.Green, 1), 0],
-          [Card(Suit.Red, 9), 1],
+          tc(R, 7, 2), // [Card(Suit.Red, 7), 2],
+          tc(G, 1, 0), // [Card(Suit.Green, 1), 0],
+          tc(R, 9, 1), // [Card(Suit.Red, 9), 1],
         ],
         trumpSuit: Suit.Green,
         winnerIndex: 1,
       },
       {
         cards: [
-          [Card(Suit.Blue, 3), 0],
-          [Card(Suit.Blue, 2), 1],
-          [Card(Suit.Red, 9), 2],
+          tc(B, 3, 0), // [Card(Suit.Blue, 3), 0],
+          tc(B, 2, 1), // [Card(Suit.Blue, 2), 1],
+          tc(R, 9, 2), // [Card(Suit.Red, 9), 2],
         ],
         trumpSuit: Suit.Blue,
         winnerIndex: 0,
       },
       {
         cards: [
-          [Card(Suit.Green, 10), 1],
-          [Card(Suit.Blue, Rank.N), 2],
-          [Card(Suit.Blue, 9), 0],
+          tc(G, 10, 1), // [Card(Suit.Green, 10), 1],
+          tc(B, N, 2), // [Card(Suit.Blue, Rank.N), 2],
+          tc(B, 9, 0), // [Card(Suit.Blue, 9), 0],
         ],
         trumpSuit: Suit.Blue,
         winnerIndex: 2,
@@ -293,9 +307,9 @@ describe("getTrickWinner", () => {
     test("first N wins if only Ns", () => {
       const { cards, trumpSuit, winnerIndex }: TestData = {
         cards: [
-          [Card(Suit.Red, Rank.N), 2],
-          [Card(Suit.Yellow, Rank.N), 0],
-          [Card(Suit.Blue, Rank.N), 1],
+          tc(R, N, 2), // [Card(Suit.Red, Rank.N), 2],
+          tc(Y, N, 0), // [Card(Suit.Yellow, Rank.N), 0],
+          tc(B, N, 1), // [Card(Suit.Blue, Rank.N), 1],
         ],
         trumpSuit: Suit.Green,
         winnerIndex: 0,
@@ -307,20 +321,20 @@ describe("getTrickWinner", () => {
       const data: TestData[] = [
         {
           cards: [
-            [Card(Suit.Red, Rank.N), 3],
-            [Card(Suit.Green, 1), 0],
-            [Card(Suit.Red, 13), 1],
-            [Card(Suit.Green, 9), 2],
+            tc(R, N, 3), // [Card(Suit.Red, Rank.N), 3],
+            tc(G, 1, 0), // [Card(Suit.Green, 1), 0],
+            tc(R, 13, 1), // [Card(Suit.Red, 13), 1],
+            tc(G, 9, 2), // [Card(Suit.Green, 9), 2],
           ],
           trumpSuit: Suit.Green,
           winnerIndex: 3,
         },
         {
           cards: [
-            [Card(Suit.Blue, Rank.N), 0],
-            [Card(Suit.Blue, 2), 1],
-            [Card(Suit.Red, 9), 2],
-            [Card(Suit.Blue, 1), 3],
+            tc(B, N, 0), // [Card(Suit.Blue, Rank.N), 0],
+            tc(B, 2, 1), // [Card(Suit.Blue, 2), 1],
+            tc(R, 9, 2), // [Card(Suit.Red, 9), 2],
+            tc(B, 1, 3), // [Card(Suit.Blue, 1), 3],
           ],
           trumpSuit: Suit.Blue,
           winnerIndex: 1,
@@ -336,19 +350,19 @@ describe("getTrickWinner", () => {
       const data: TestData[] = [
         {
           cards: [
-            [Card(Suit.Red, Rank.N), 0],
-            [Card(Suit.Yellow, 13), 1],
-            [Card(Suit.Red, 9), 2],
+            tc(R, N, 0), // [Card(Suit.Red, Rank.N), 0],
+            tc(Y, 13, 1), // [Card(Suit.Yellow, 13), 1],
+            tc(R, 9, 2), // [Card(Suit.Red, 9), 2],
           ],
           trumpSuit: Suit.Green,
           winnerIndex: 1,
         },
         {
           cards: [
-            [Card(Suit.Blue, Rank.N), 2],
-            [Card(Suit.Blue, 2), 3],
-            [Card(Suit.Red, 9), 0],
-            [Card(Suit.Blue, 5), 1],
+            tc(B, N, 2), // [Card(Suit.Blue, Rank.N), 2],
+            tc(B, 2, 3), // [Card(Suit.Blue, 2), 3],
+            tc(R, 9, 0), // [Card(Suit.Red, 9), 0],
+            tc(B, 5, 1), // [Card(Suit.Blue, 5), 1],
           ],
           trumpSuit: Suit.Green,
           winnerIndex: 3,
@@ -356,10 +370,10 @@ describe("getTrickWinner", () => {
         // N card is of trump suit
         {
           cards: [
-            [Card(Suit.Green, Rank.N), 2],
-            [Card(Suit.Blue, 2), 3],
-            [Card(Suit.Red, 9), 0],
-            [Card(Suit.Blue, 5), 1],
+            tc(G, N, 2), // [Card(Suit.Green, Rank.N), 2],
+            tc(B, 2, 3), // [Card(Suit.Blue, 2), 3],
+            tc(R, 9, 0), // [Card(Suit.Red, 9), 0],
+            tc(B, 5, 1), // [Card(Suit.Blue, 5), 1],
           ],
           trumpSuit: Suit.Green,
           winnerIndex: 3,

--- a/src/game/entities/cards.utils.ts
+++ b/src/game/entities/cards.utils.ts
@@ -1,6 +1,5 @@
 import flatten from "lodash/flatten";
 import groupBy from "lodash/groupBy";
-import { PlayerID } from "./players";
 import { Suit, SuitLabel, Rank, Card, allSuits, allRanks } from "./cards";
 import { checkTrickCards } from "./trick.utils";
 import { TrickCard } from "./trick";
@@ -75,19 +74,24 @@ export function cardBeatsOther(
 export function getTrickWinner(
   cards: TrickCard[],
   trumpSuit: Suit | null
-): [Card, PlayerID] {
+): TrickCard {
   if (cards.length === 0) {
     throw new Error("expected non-empty array of cards");
   }
   if (!checkTrickCards(cards)) {
     throw new Error("expected no undefined cards");
   }
-  const leadSuit = getLeadSuit(cards.map(([card]) => card));
-  const winner = cards.reduce((winningCard, card, cardIndex) => {
+  const leadSuit = getLeadSuit(cards.map(({ card }) => card));
+  const winner = cards.reduce((winningCard, trickCard, cardIndex) => {
     // skip first card
     if (cardIndex === 0) return winningCard;
-    const beaten = cardBeatsOther(card[0], winningCard[0], trumpSuit, leadSuit);
-    return beaten ? card : winningCard;
+    const beaten = cardBeatsOther(
+      trickCard.card,
+      winningCard.card,
+      trumpSuit,
+      leadSuit
+    );
+    return beaten ? trickCard : winningCard;
   }, cards[0]);
   return winner;
 }

--- a/src/game/entities/cards.utils.ts
+++ b/src/game/entities/cards.utils.ts
@@ -2,6 +2,8 @@ import flatten from "lodash/flatten";
 import groupBy from "lodash/groupBy";
 import { PlayerID } from "./players";
 import { Suit, SuitLabel, Rank, Card, allSuits, allRanks } from "./cards";
+import { checkTrickCards } from "./trick.utils";
+import { TrickCard } from "./trick";
 
 /**
  * checks if a card wins over another card given specified trump and lead suits
@@ -71,11 +73,14 @@ export function cardBeatsOther(
  * @returns {[Card, PlayerID]}
  */
 export function getTrickWinner(
-  cards: [Card, PlayerID][],
+  cards: TrickCard[],
   trumpSuit: Suit | null
 ): [Card, PlayerID] {
   if (cards.length === 0) {
     throw new Error("expected non-empty array of cards");
+  }
+  if (!checkTrickCards(cards)) {
+    throw new Error("expected no undefined cards");
   }
   const leadSuit = getLeadSuit(cards.map(([card]) => card));
   const winner = cards.reduce((winningCard, card, cardIndex) => {

--- a/src/game/entities/players.utils.ts
+++ b/src/game/entities/players.utils.ts
@@ -24,6 +24,21 @@ export function playersRound(
 }
 
 /**
+ * Gets the next player in the round.
+ *
+ * @export
+ * @param {PlayerID} currentPlayer current player
+ * @param {NumPlayers} numPlayers total number of players in roudn
+ * @returns {PlayerID} next player in round
+ */
+export function nextPlayer(
+  currentPlayer: PlayerID,
+  numPlayers: NumPlayers
+): PlayerID {
+  return ((currentPlayer + 1) % numPlayers) as PlayerID;
+}
+
+/**
  * Gets the name for a given playerID. If no name is found, the playerID is converted to a string.
  *
  * @export

--- a/src/game/entities/trick.ts
+++ b/src/game/entities/trick.ts
@@ -1,5 +1,10 @@
 import { PlayerID } from "./players";
 import { Card } from "./cards";
 
-export type OptionalTrickCard = [Card | undefined, PlayerID];
-export type TrickCard = [Card, PlayerID];
+export interface OptionalTrickCard {
+  card: Card | undefined;
+  player: PlayerID;
+}
+export interface TrickCard extends OptionalTrickCard {
+  card: Card;
+}

--- a/src/game/entities/trick.ts
+++ b/src/game/entities/trick.ts
@@ -1,0 +1,5 @@
+import { PlayerID } from "./players";
+import { Card } from "./cards";
+
+export type OptionalTrickCard = [Card | undefined, PlayerID];
+export type TrickCard = [Card, PlayerID];

--- a/src/game/entities/trick.utils.ts
+++ b/src/game/entities/trick.utils.ts
@@ -1,0 +1,13 @@
+import { OptionalTrickCard, TrickCard } from "./trick";
+
+export function checkTrickCard(
+  optionalTrickCard: OptionalTrickCard
+): optionalTrickCard is TrickCard {
+  return !!optionalTrickCard[0];
+}
+
+export function checkTrickCards(
+  optionalTrickCards: OptionalTrickCard[]
+): optionalTrickCards is TrickCard[] {
+  return optionalTrickCards.every(checkTrickCard);
+}

--- a/src/game/entities/trick.utils.ts
+++ b/src/game/entities/trick.utils.ts
@@ -3,7 +3,7 @@ import { OptionalTrickCard, TrickCard } from "./trick";
 export function checkTrickCard(
   optionalTrickCard: OptionalTrickCard
 ): optionalTrickCard is TrickCard {
-  return !!optionalTrickCard[0];
+  return !!optionalTrickCard.card;
 }
 
 export function checkTrickCards(

--- a/src/game/phases/setup.test.ts
+++ b/src/game/phases/setup.test.ts
@@ -102,7 +102,7 @@ describe("handout", () => {
     const ctx = generateCtx({ numPlayers: 4 });
     const g = generateDefaultWizardState(ctx, { numCards: 15 });
     handoutMove(g, ctx);
-    expect(g.round!.trump.card).toBeNull();
+    expect(g.round!.trump.card).toBeUndefined();
     expect(g.round!.trump.suit).toBeNull();
   });
 

--- a/src/game/phases/setup.ts
+++ b/src/game/phases/setup.ts
@@ -43,11 +43,11 @@ export function handoutMove(wizardState: WizardState, ctx: Ctx): void {
   round.hands = hands;
 
   // draw trump card
-  let trumpCard: Card | null = null;
+  let trumpCard: Card | undefined;
   let trumpSuit: Suit | null | undefined = null;
 
   if (round.deck.length > 0) {
-    trumpCard = round.deck.pop() ?? null;
+    trumpCard = round.deck.pop() ?? undefined;
     trumpSuit = trumpCard?.suit ?? null;
     if (trumpCard?.rank === Rank.N) {
       trumpSuit = null;

--- a/src/ui/components/PlayCard.tsx
+++ b/src/ui/components/PlayCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { cardColors, ColorSet, colors } from "../util/colors";
 import { Card, Rank, Suit } from "../../game/entities/cards";
 import {
@@ -70,11 +70,13 @@ const BacksideCardBox = styled(StaticCardBox)`
   text-shadow: 0 0 8px ${cardColors.back.shadow};
 `;
 
-const FronsideCardBox = styled(StaticCardBox)<{
+interface FrontsideCardBoxProps {
   colorSet: ColorSet;
   isplayable: boolean;
   isdisabled: boolean;
-}>`
+}
+
+const FronsideCardBox = styled(StaticCardBox)<FrontsideCardBoxProps>`
   font-size: 36px;
   font-weight: bold;
   /* colors */
@@ -85,17 +87,19 @@ const FronsideCardBox = styled(StaticCardBox)<{
   -webkit-text-stroke: 2px ${({ colorSet }) => colorSet.outline};
   ${({ isplayable, isdisabled }) =>
     isplayable && !isdisabled
-      ? `cursor: pointer;
-    transition: transform 0.3s;
-    &:hover {
-      transform: translate(0, -10px);
-    }`
+      ? css`
+          cursor: pointer;
+          transition: transform 0.3s;
+          &:hover {
+            transform: translate(0, -10px);
+          }
+        `
       : ""}
   ${({ isdisabled: isDisabled }) =>
     isDisabled
-      ? `
-  background-color: #ffffff;
-  `
+      ? css`
+          background-color: #ffffff;
+        `
       : ""}
   & span {
     border-bottom: 2px solid ${({ colorSet }) => colorSet.text};

--- a/src/ui/components/playcard/PlayCard.tsx
+++ b/src/ui/components/playcard/PlayCard.tsx
@@ -1,18 +1,11 @@
 import React from "react";
-import styled, { css } from "styled-components";
-import { cardColors, ColorSet, colors } from "../../util/colors";
-import { Card, Rank, Suit } from "../../../game/entities/cards";
-import {
-  getCardLabel,
-  getRankLabel,
-  getCardId,
-} from "../../../game/entities/cards.utils";
+import { Card } from "../../../game/entities/cards";
+import { PlayCardFrontsideProps, PlayCardFrontside } from "./PlayCardFrontside";
+import { PlayCardPlaceholder } from "./PlayCardPlaceholder";
+import { PlayCardBackside } from "./PlayCardBackside";
 
-export interface PlayCardProps {
-  card: Card | null;
-  interactive?: boolean;
-  disabled?: boolean;
-  onClick?: () => void;
+export interface PlayCardProps extends Omit<PlayCardFrontsideProps, "card"> {
+  card: Card | null | undefined;
 }
 
 export const PlayCard: React.FC<PlayCardProps> = ({
@@ -21,106 +14,18 @@ export const PlayCard: React.FC<PlayCardProps> = ({
   disabled = false,
   onClick = () => {},
 }) => {
-  if (!card) {
-    return <BacksideCardBox>Wizard</BacksideCardBox>;
+  if (card === undefined) {
+    return <PlayCardPlaceholder />;
   }
-  const colorSet = getColor(card);
-  const label = getRankLabel(card);
-
-  const guardedOnClick = (): void => {
-    if (interactive && !disabled) onClick();
-  };
-
+  if (card === null) {
+    return <PlayCardBackside />;
+  }
   return (
-    <FronsideCardBox
-      onClick={guardedOnClick}
-      isplayable={interactive}
-      isdisabled={disabled}
-      colorSet={colorSet}
-      aria-label={getCardLabel(card)}
-      data-testid={getCardId(card)}
-    >
-      <span>{label}</span>
-    </FronsideCardBox>
+    <PlayCardFrontside
+      card={card}
+      interactive={interactive}
+      disabled={disabled}
+      onClick={onClick}
+    />
   );
 };
-
-const StaticCardBox = styled.div`
-  border: 1px solid ${colors.grey};
-  border-radius: 7px;
-  padding: 5px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  width: 46px;
-  height: 71px;
-  font-family: "Almendra", serif;
-  font-weight: 700;
-`;
-
-const BacksideCardBox = styled(StaticCardBox)`
-  font-size: 15px;
-  font-style: italic;
-  background-color: ${cardColors.back.background};
-  color: ${cardColors.back.outline};
-  /* text-outline effect only supported with prefix */
-  -webkit-text-fill-color: ${cardColors.back.text};
-  -webkit-text-stroke: 1px ${cardColors.back.outline};
-  text-shadow: 0 0 8px ${cardColors.back.shadow};
-`;
-
-interface FrontsideCardBoxProps {
-  colorSet: ColorSet;
-  isplayable: boolean;
-  isdisabled: boolean;
-}
-
-const FronsideCardBox = styled(StaticCardBox)<FrontsideCardBoxProps>`
-  font-size: 36px;
-  font-weight: bold;
-  /* colors */
-  background-color: ${({ colorSet }) => colorSet.background};
-  color: ${({ colorSet }) => colorSet.outline};
-  /* cool outline effect only supported with prefix */
-  -webkit-text-fill-color: ${({ colorSet }) => colorSet.text};
-  -webkit-text-stroke: 2px ${({ colorSet }) => colorSet.outline};
-  ${({ isplayable, isdisabled }) =>
-    isplayable && !isdisabled
-      ? css`
-          cursor: pointer;
-          transition: transform 0.3s;
-          &:hover {
-            transform: translate(0, -10px);
-          }
-        `
-      : ""}
-  ${({ isdisabled: isDisabled }) =>
-    isDisabled
-      ? css`
-          background-color: #ffffff;
-        `
-      : ""}
-  & span {
-    border-bottom: 2px solid ${({ colorSet }) => colorSet.text};
-  }
-`;
-
-function getColor({ rank, suit }: Card): ColorSet {
-  if (rank === Rank.Z || rank === Rank.N) {
-    return cardColors.zn;
-  }
-  switch (suit) {
-    case Suit.Blue:
-      return cardColors.blue;
-    case Suit.Green:
-      return cardColors.green;
-    case Suit.Red:
-      return cardColors.red;
-    case Suit.Yellow:
-      return cardColors.yellow;
-    // fallback
-    default:
-      return cardColors.zn;
-  }
-}

--- a/src/ui/components/playcard/PlayCard.tsx
+++ b/src/ui/components/playcard/PlayCard.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import styled, { css } from "styled-components";
-import { cardColors, ColorSet, colors } from "../util/colors";
-import { Card, Rank, Suit } from "../../game/entities/cards";
+import { cardColors, ColorSet, colors } from "../../util/colors";
+import { Card, Rank, Suit } from "../../../game/entities/cards";
 import {
   getCardLabel,
   getRankLabel,
   getCardId,
-} from "../../game/entities/cards.utils";
+} from "../../../game/entities/cards.utils";
 
 export interface PlayCardProps {
   card: Card | null;

--- a/src/ui/components/playcard/PlayCardBackside.tsx
+++ b/src/ui/components/playcard/PlayCardBackside.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import styled from "styled-components";
+import { playCardBaseStyles } from "./playcard.styles";
+import { cardColors } from "../../util/colors";
+
+export const PlayCardBackside: React.FC = () => {
+  return <BacksideContainer>Wizard</BacksideContainer>;
+};
+
+const BacksideContainer = styled.div`
+  ${playCardBaseStyles}
+  font-size: 15px;
+  font-style: italic;
+  background-color: ${cardColors.back.background};
+  color: ${cardColors.back.outline};
+  /* text-outline effect only supported with prefix */
+  -webkit-text-fill-color: ${cardColors.back.text};
+  -webkit-text-stroke: 1px ${cardColors.back.outline};
+  text-shadow: 0 0 8px ${cardColors.back.shadow};
+`;

--- a/src/ui/components/playcard/PlayCardFrontside.tsx
+++ b/src/ui/components/playcard/PlayCardFrontside.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import styled, { css } from "styled-components";
+import { playCardBaseStyles } from "./playcard.styles";
+import { ColorSet } from "../../util/colors";
+import { getColor } from "./playcard.utils";
+import {
+  getRankLabel,
+  getCardLabel,
+  getCardId,
+} from "../../../game/entities/cards.utils";
+import { Card } from "../../../game/entities/cards";
+
+export interface PlayCardFrontsideProps {
+  card: Card;
+  interactive?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+export const PlayCardFrontside: React.FC<PlayCardFrontsideProps> = ({
+  card,
+  interactive = true,
+  disabled = false,
+  onClick = () => {},
+}) => {
+  const colorSet = getColor(card);
+  const label = getRankLabel(card);
+  const guardedOnClick = (): void => {
+    if (interactive && !disabled) onClick();
+  };
+  return (
+    <FronsideCardBox
+      onClick={guardedOnClick}
+      isplayable={interactive}
+      isdisabled={disabled}
+      colorSet={colorSet}
+      aria-label={getCardLabel(card)}
+      data-testid={getCardId(card)}
+    >
+      <span>{label}</span>
+    </FronsideCardBox>
+  );
+};
+
+interface FrontsideCardBoxProps {
+  colorSet: ColorSet;
+  isplayable: boolean;
+  isdisabled: boolean;
+}
+
+const FronsideCardBox = styled.div<FrontsideCardBoxProps>`
+  ${playCardBaseStyles}
+  font-size: 36px;
+  font-weight: bold;
+  /* colors */
+  background-color: ${({ colorSet }) => colorSet.background};
+  color: ${({ colorSet }) => colorSet.outline};
+  /* cool outline effect only supported with prefix */
+  -webkit-text-fill-color: ${({ colorSet }) => colorSet.text};
+  -webkit-text-stroke: 2px ${({ colorSet }) => colorSet.outline};
+  ${({ isplayable, isdisabled }) =>
+    isplayable && !isdisabled
+      ? css`
+          cursor: pointer;
+          transition: transform 0.3s;
+          &:hover {
+            transform: translate(0, -10px);
+          }
+        `
+      : ""}
+  ${({ isdisabled: isDisabled }) =>
+    isDisabled
+      ? css`
+          background-color: #ffffff;
+        `
+      : ""}
+  & span {
+    border-bottom: 2px solid ${({ colorSet }) => colorSet.text};
+  }
+`;

--- a/src/ui/components/playcard/PlayCardPlaceholder.tsx
+++ b/src/ui/components/playcard/PlayCardPlaceholder.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { playCardBaseStyles } from "./playcard.styles";
+import { colors } from "../../util/colors";
 
 export const PlayCardPlaceholder: React.FC = ({ children }) => {
   return <PlaceholderContainer>{children}</PlaceholderContainer>;
@@ -8,4 +9,5 @@ export const PlayCardPlaceholder: React.FC = ({ children }) => {
 
 const PlaceholderContainer = styled.div`
   ${playCardBaseStyles}
+  background-color: ${colors.lightgrey};
 `;

--- a/src/ui/components/playcard/PlayCardPlaceholder.tsx
+++ b/src/ui/components/playcard/PlayCardPlaceholder.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const PlayCardPlaceholder: React.FC = () => {
+  return null;
+};

--- a/src/ui/components/playcard/PlayCardPlaceholder.tsx
+++ b/src/ui/components/playcard/PlayCardPlaceholder.tsx
@@ -10,4 +10,5 @@ export const PlayCardPlaceholder: React.FC = ({ children }) => {
 const PlaceholderContainer = styled.div`
   ${playCardBaseStyles}
   background-color: ${colors.lightgrey};
+  opacity: .6;
 `;

--- a/src/ui/components/playcard/PlayCardPlaceholder.tsx
+++ b/src/ui/components/playcard/PlayCardPlaceholder.tsx
@@ -1,5 +1,11 @@
 import React from "react";
+import styled from "styled-components";
+import { playCardBaseStyles } from "./playcard.styles";
 
-export const PlayCardPlaceholder: React.FC = () => {
-  return null;
+export const PlayCardPlaceholder: React.FC = ({ children }) => {
+  return <PlaceholderContainer>{children}</PlaceholderContainer>;
 };
+
+const PlaceholderContainer = styled.div`
+  ${playCardBaseStyles}
+`;

--- a/src/ui/components/playcard/playcard.styles.ts
+++ b/src/ui/components/playcard/playcard.styles.ts
@@ -1,0 +1,16 @@
+import { css } from "styled-components";
+import { colors } from "../../util/colors";
+
+export const playCardBaseStyles = css`
+  border: 1px solid ${colors.grey};
+  border-radius: 7px;
+  padding: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  width: 46px;
+  height: 71px;
+  font-family: "Almendra", serif;
+  font-weight: 700;
+`;

--- a/src/ui/components/playcard/playcard.utils.ts
+++ b/src/ui/components/playcard/playcard.utils.ts
@@ -1,0 +1,21 @@
+import { Card, Rank, Suit } from "../../../game/entities/cards";
+import { ColorSet, cardColors } from "../../util/colors";
+
+export function getColor({ rank, suit }: Card): ColorSet {
+  if (rank === Rank.Z || rank === Rank.N) {
+    return cardColors.zn;
+  }
+  switch (suit) {
+    case Suit.Blue:
+      return cardColors.blue;
+    case Suit.Green:
+      return cardColors.green;
+    case Suit.Red:
+      return cardColors.red;
+    case Suit.Yellow:
+      return cardColors.yellow;
+    // fallback
+    default:
+      return cardColors.zn;
+  }
+}

--- a/src/ui/hooks/notify-trick-complete.ts
+++ b/src/ui/hooks/notify-trick-complete.ts
@@ -5,23 +5,24 @@ import { useNotify } from "../NotificationsProvider";
 import { getPlayerName } from "../../game/entities/players.utils";
 import { useGameEventHandler } from "./game-event-handler";
 import { GameState } from "../GameState";
+import { checkTrickCard } from "../../game/entities/trick.utils";
 
 export function useNotifyTrickComplete(): void {
   const notify = useNotify();
 
   const handleTrickComplete = useCallback(
     ({ wizardState: { round, trick }, gameMetadata, clientID }: GameState) => {
-      const trickCards = trick?.cards;
+      const trickCards = trick?.cards.filter(checkTrickCard);
       const trumpSuit = round?.trump.suit ?? null;
 
       if (trickCards) {
-        const [, trickWinner] = getTrickWinner(trickCards, trumpSuit);
+        const { player } = getTrickWinner(trickCards, trumpSuit);
         let message: string;
 
-        if (trickWinner === clientID) {
+        if (player === clientID) {
           message = "Du gewinnst den Stich!";
         } else {
-          const trickWinnerName = getPlayerName(trickWinner, gameMetadata);
+          const trickWinnerName = getPlayerName(player, gameMetadata);
           message = `${trickWinnerName} gewinnt den Stich!`;
         }
 

--- a/src/ui/player/ClientHand.tsx
+++ b/src/ui/player/ClientHand.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { playableCardsInHand } from "../../game/entities/cards.utils";
-import { PlayCard } from "../components/PlayCard";
+import { PlayCard } from "../components/playcard/PlayCard";
 import { Card } from "../../game/entities/cards";
 
 export interface HandCardsProps {

--- a/src/ui/player/OpponentHand.tsx
+++ b/src/ui/player/OpponentHand.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import range from "lodash/range";
 import styled from "styled-components";
-import { PlayCard } from "../components/PlayCard";
+import { PlayCard } from "../components/playcard/PlayCard";
 
 export interface OpponentHandProps {
   numCards: number;

--- a/src/ui/table/BidRound.tsx
+++ b/src/ui/table/BidRound.tsx
@@ -1,5 +1,48 @@
 import React from "react";
+import styled from "styled-components";
+import { useGameState } from "../GameContext";
+import { isSetRound } from "../../game/WizardState";
+import {
+  playersRound,
+  nextPlayer,
+  getPlayerName,
+} from "../../game/entities/players.utils";
+import { TrickCardBox } from "./TrickCardBox";
+import { colors } from "../util/colors";
 
 export const BidRound: React.FC = () => {
-  return <div>Bid Round!</div>;
+  const {
+    wizardState: { numPlayers, dealer, round, numCards },
+    gameMetadata,
+  } = useGameState();
+
+  if (!isSetRound(round)) {
+    return null;
+  }
+  const { bids } = round;
+  const totalBids = bids.reduce((sum: number, bid) => sum + (bid ?? 0), 0);
+  const bidRoundOrder = playersRound(
+    nextPlayer(dealer, numPlayers),
+    numPlayers
+  );
+  return (
+    <>
+      {bidRoundOrder.map((playerID) => (
+        <TrickCardBox player={getPlayerName(playerID, gameMetadata)}>
+          <h2>{bids[playerID] ?? "_"}</h2>
+        </TrickCardBox>
+      ))}
+      <TrickCardBox player="TOTAL">
+        <TotalBox>
+          <h2>
+            {totalBids} von {numCards}
+          </h2>
+        </TotalBox>
+      </TrickCardBox>
+    </>
+  );
 };
+
+const TotalBox = styled.div`
+  color: ${colors.wizard.green};
+`;

--- a/src/ui/table/BidRound.tsx
+++ b/src/ui/table/BidRound.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const BidRound: React.FC = () => {
+  return <div>Bid Round!</div>;
+};

--- a/src/ui/table/Deck.tsx
+++ b/src/ui/table/Deck.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { Suit } from "../../game/entities/cards";
 import { PlayCard } from "../components/playcard/PlayCard";
 import { useGameState } from "../GameContext";
@@ -19,7 +19,7 @@ export const Deck: React.FC = () => {
 
   return (
     <DeckContainer trump={color.text}>
-      <CardOutline>
+      <CardOutline disabled={trump.card === undefined}>
         <PlayCard card={trump.card} interactive={false} />
       </CardOutline>
     </DeckContainer>
@@ -39,9 +39,14 @@ const DeckContainer = styled.div<{ trump: string }>`
   margin-right: 25px;
 `;
 
-const CardOutline = styled.div`
-  border-radius: 7px;
-  box-shadow: -2px 2px 2px black;
+const CardOutline = styled.div<{ disabled?: boolean }>`
+  ${({ disabled }) =>
+    disabled
+      ? ""
+      : css`
+          border-radius: 7px;
+          box-shadow: -2px 2px 2px black;
+        `}
 `;
 
 function getColor(suit: Suit | null | undefined): ColorSet {

--- a/src/ui/table/Deck.tsx
+++ b/src/ui/table/Deck.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { Suit } from "../../game/entities/cards";
-import { PlayCard } from "../components/PlayCard";
+import { PlayCard } from "../components/playcard/PlayCard";
 import { useGameState } from "../GameContext";
 import { isSetRound } from "../../game/WizardState";
 import { cardColors, ColorSet } from "../util/colors";

--- a/src/ui/table/Table.tsx
+++ b/src/ui/table/Table.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import styled from "styled-components";
-import { Trick } from "./Trick";
 import { Deck } from "./Deck";
 import { colors } from "../util/colors";
 import { ActionsContainer } from "../player/actions/ActionsContainer";
 import { useGameState, usePlayerName } from "../GameContext";
+import { TableRound } from "./TableRound";
 
 export const Table: React.FC = () => {
   const {
@@ -19,7 +19,7 @@ export const Table: React.FC = () => {
     <TableContainer>
       <PlayRow data-testid="table-play">
         <Deck />
-        <Trick />
+        <TableRound />
       </PlayRow>
       <InfoRow data-testid="table-info">
         {isTurn && <ActionsContainer phase={phase} />}

--- a/src/ui/table/Table.tsx
+++ b/src/ui/table/Table.tsx
@@ -20,7 +20,6 @@ export const Table: React.FC = () => {
       <PlayRow data-testid="table-play">
         <Deck />
         <Trick />
-        <SpaceFill />
       </PlayRow>
       <InfoRow data-testid="table-info">
         {isTurn && <ActionsContainer phase={phase} />}
@@ -50,6 +49,8 @@ const PlayRow = styled.div`
   align-items: center;
   border-bottom: 1px solid ${colors.wood.dark};
   padding-bottom: 25px;
+  min-height: 140px;
+  box-sizing: border-box;
 `;
 
 const InfoRow = styled.div`

--- a/src/ui/table/TableRound.tsx
+++ b/src/ui/table/TableRound.tsx
@@ -2,20 +2,13 @@ import React from "react";
 import styled from "styled-components";
 import { useGameState } from "../GameContext";
 import { Trick } from "./Trick";
-import { Phase } from "../../game/phases/phase";
 import { BidRound } from "./BidRound";
 
 export const TableRound: React.FC = () => {
   const {
     wizardState: { trick, round },
-    ctx: { phase },
   } = useGameState();
-  return (
-    <Container>
-      {trick && round && <Trick />}
-      {phase === Phase.Bidding && <BidRound />}
-    </Container>
-  );
+  return <Container>{trick && round ? <Trick /> : <BidRound />}</Container>;
 };
 
 const Container = styled.div`

--- a/src/ui/table/TableRound.tsx
+++ b/src/ui/table/TableRound.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import styled from "styled-components";
+import { useGameState } from "../GameContext";
+import { Trick } from "./Trick";
+import { Phase } from "../../game/phases/phase";
+import { BidRound } from "./BidRound";
+
+export const TableRound: React.FC = () => {
+  const {
+    wizardState: { trick, round },
+    ctx: { phase },
+  } = useGameState();
+  return (
+    <Container>
+      {trick && round && <Trick />}
+      {phase === Phase.Bidding && <BidRound />}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+`;

--- a/src/ui/table/Trick.tsx
+++ b/src/ui/table/Trick.tsx
@@ -5,7 +5,6 @@ import { isSetTrick, isSetRound } from "../../game/WizardState";
 import { PlayCard } from "../components/playcard/PlayCard";
 import { getPlayerName } from "../../game/entities/players.utils";
 import { getTrickWinner } from "../../game/entities/cards.utils";
-import { colors } from "../util/colors";
 import { PlayerID } from "../../game/entities/players";
 import { checkTrickCard } from "../../game/entities/trick.utils";
 import { TrickCard } from "../../game/entities/trick";
@@ -34,21 +33,17 @@ export const Trick: React.FC = () => {
   return (
     <Container>
       {cards.map(({ card, player }) => (
-        <TrickCardBox player={getPlayerName(player, gameMetadata)} key={player}>
-          <PlayingCardOutline isWinning={player === winningPlayerID}>
-            <PlayCard card={card} interactive={false} />
-          </PlayingCardOutline>
+        <TrickCardBox
+          player={getPlayerName(player, gameMetadata)}
+          isWinning={player === winningPlayerID}
+          key={player}
+        >
+          <PlayCard card={card} interactive={false} />
         </TrickCardBox>
       ))}
     </Container>
   );
 };
-
-const PlayingCardOutline = styled.div<{ isWinning: boolean }>`
-  border-radius: 7px;
-  border: 2px solid
-    ${({ isWinning }) => (isWinning ? colors.wizard.green : "transparent")};
-`;
 
 const Container = styled.div`
   display: flex;

--- a/src/ui/table/Trick.tsx
+++ b/src/ui/table/Trick.tsx
@@ -3,7 +3,7 @@ import { Badge, Tooltip } from "@material-ui/core";
 import styled from "styled-components";
 import { useGameState } from "../GameContext";
 import { isSetTrick, isSetRound } from "../../game/WizardState";
-import { PlayCard } from "../components/PlayCard";
+import { PlayCard } from "../components/playcard/PlayCard";
 import { getPlayerName } from "../../game/entities/players.utils";
 import { getTrickWinner } from "../../game/entities/cards.utils";
 import { colors } from "../util/colors";

--- a/src/ui/table/Trick.tsx
+++ b/src/ui/table/Trick.tsx
@@ -24,26 +24,26 @@ export const Trick: React.FC = () => {
     checkTrickCard(optTrickCard)
   ) as TrickCard[];
   if (playedCardsInTrick.length > 0) {
-    const [, trickWinner] = getTrickWinner(
+    const { player } = getTrickWinner(
       playedCardsInTrick,
       round?.trump.suit || null
     );
-    winningPlayerID = trickWinner;
+    winningPlayerID = player;
   }
 
   return (
     <Container>
-      {cards.map(([card, playerID]) => (
+      {cards.map(({ card, player }) => (
         <PlayingCardContainer
-          isWinning={playerID === winningPlayerID}
-          key={playerID}
+          isWinning={player === winningPlayerID}
+          key={player}
         >
           <Tooltip
-            title={getPlayerName(playerID, gameMetadata)}
+            title={getPlayerName(player, gameMetadata)}
             placement="bottom"
           >
             <Badge
-              badgeContent={getPlayerName(playerID, gameMetadata, 7)}
+              badgeContent={getPlayerName(player, gameMetadata, 7)}
               color="primary"
             >
               <PlayCard card={card} interactive={false} />

--- a/src/ui/table/Trick.tsx
+++ b/src/ui/table/Trick.tsx
@@ -16,7 +16,8 @@ export const Trick: React.FC = () => {
     gameMetadata,
   } = useGameState();
 
-  if (!isSetTrick(trick) || !isSetRound(round)) return null;
+  if (!isSetTrick(trick) || !isSetRound(round))
+    return <span>Round or trick is null</span>;
   const { cards } = trick;
   let winningPlayerID: PlayerID;
   const playedCardsInTrick = cards.filter((optTrickCard) =>

--- a/src/ui/table/Trick.tsx
+++ b/src/ui/table/Trick.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Badge, Tooltip } from "@material-ui/core";
 import styled from "styled-components";
 import { useGameState } from "../GameContext";
 import { isSetTrick, isSetRound } from "../../game/WizardState";
@@ -10,6 +9,7 @@ import { colors } from "../util/colors";
 import { PlayerID } from "../../game/entities/players";
 import { checkTrickCard } from "../../game/entities/trick.utils";
 import { TrickCard } from "../../game/entities/trick";
+import { TrickCardBox } from "./TrickCardBox";
 
 export const Trick: React.FC = () => {
   const {
@@ -34,29 +34,17 @@ export const Trick: React.FC = () => {
   return (
     <Container>
       {cards.map(({ card, player }) => (
-        <PlayingCardContainer
-          isWinning={player === winningPlayerID}
-          key={player}
-        >
-          <Tooltip
-            title={getPlayerName(player, gameMetadata)}
-            placement="bottom"
-          >
-            <Badge
-              badgeContent={getPlayerName(player, gameMetadata, 7)}
-              color="primary"
-            >
-              <PlayCard card={card} interactive={false} />
-            </Badge>
-          </Tooltip>
-        </PlayingCardContainer>
+        <TrickCardBox player={getPlayerName(player, gameMetadata)} key={player}>
+          <PlayingCardOutline isWinning={player === winningPlayerID}>
+            <PlayCard card={card} interactive={false} />
+          </PlayingCardOutline>
+        </TrickCardBox>
       ))}
     </Container>
   );
 };
 
-const PlayingCardContainer = styled.div<{ isWinning: boolean }>`
-  margin: 10px;
+const PlayingCardOutline = styled.div<{ isWinning: boolean }>`
   border-radius: 7px;
   border: 2px solid
     ${({ isWinning }) => (isWinning ? colors.wizard.green : "transparent")};
@@ -65,4 +53,5 @@ const PlayingCardContainer = styled.div<{ isWinning: boolean }>`
 const Container = styled.div`
   display: flex;
   flex-direction: row;
+  flex-grow: 1;
 `;

--- a/src/ui/table/Trick.tsx
+++ b/src/ui/table/Trick.tsx
@@ -8,6 +8,8 @@ import { getPlayerName } from "../../game/entities/players.utils";
 import { getTrickWinner } from "../../game/entities/cards.utils";
 import { colors } from "../util/colors";
 import { PlayerID } from "../../game/entities/players";
+import { checkTrickCard } from "../../game/entities/trick.utils";
+import { TrickCard } from "../../game/entities/trick";
 
 export const Trick: React.FC = () => {
   const {
@@ -17,10 +19,15 @@ export const Trick: React.FC = () => {
 
   if (!isSetTrick(trick) || !isSetRound(round)) return null;
   const { cards } = trick;
-
   let winningPlayerID: PlayerID;
-  if (cards.length > 0) {
-    const [, trickWinner] = getTrickWinner(cards, round?.trump.suit || null);
+  const playedCardsInTrick = cards.filter((optTrickCard) =>
+    checkTrickCard(optTrickCard)
+  ) as TrickCard[];
+  if (playedCardsInTrick.length > 0) {
+    const [, trickWinner] = getTrickWinner(
+      playedCardsInTrick,
+      round?.trump.suit || null
+    );
     winningPlayerID = trickWinner;
   }
 
@@ -29,7 +36,7 @@ export const Trick: React.FC = () => {
       {cards.map(([card, playerID]) => (
         <PlayingCardContainer
           isWinning={playerID === winningPlayerID}
-          key={`${card.suit}-${card.rank}`}
+          key={playerID}
         >
           <Tooltip
             title={getPlayerName(playerID, gameMetadata)}

--- a/src/ui/table/TrickCardBox.tsx
+++ b/src/ui/table/TrickCardBox.tsx
@@ -26,10 +26,10 @@ export const TrickCardBox: React.FC<TrickCardProps> = ({
 const Container = styled.div<{ outlineColor: string }>`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   align-items: center;
   flex-grow: 1;
   max-width: 150px;
+  height: 95px;
   margin: 0 5px;
   padding: 8px 10px;
   background-color: ${colors.lightTransparentGrey};
@@ -39,6 +39,7 @@ const Container = styled.div<{ outlineColor: string }>`
 
 const Spacer = styled.div`
   margin: 3px 0;
+  flex-grow: 1;
 `;
 
 const PlayerBox = styled.div`

--- a/src/ui/table/TrickCardBox.tsx
+++ b/src/ui/table/TrickCardBox.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import styled from "styled-components";
+import { colors } from "../util/colors";
+
+export interface TrickCardProps {
+  player: string;
+}
+
+export const TrickCardBox: React.FC<TrickCardProps> = ({
+  player,
+  children,
+}) => {
+  return (
+    <Container>
+      {children}
+      <Spacer />
+      <PlayerBox>{player}</PlayerBox>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  flex-grow: 1;
+  max-width: 150px;
+  margin: 0 5px;
+  padding: 8px 10px;
+  background-color: ${colors.lightTransparentGrey};
+  border-radius: 7px;
+`;
+
+const Spacer = styled.div`
+  margin: 3px 0;
+`;
+
+const PlayerBox = styled.div`
+  min-width: 70px;
+  max-width: 100%;
+  font-size: 14px;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/src/ui/table/TrickCardBox.tsx
+++ b/src/ui/table/TrickCardBox.tsx
@@ -4,14 +4,18 @@ import { colors } from "../util/colors";
 
 export interface TrickCardProps {
   player: string;
+  isWinning?: boolean;
 }
 
 export const TrickCardBox: React.FC<TrickCardProps> = ({
   player,
   children,
+  isWinning = false,
 }) => {
+  const outlineColor = isWinning ? colors.wizard.green : "transparent";
+
   return (
-    <Container>
+    <Container outlineColor={outlineColor}>
       {children}
       <Spacer />
       <PlayerBox>{player}</PlayerBox>
@@ -19,7 +23,7 @@ export const TrickCardBox: React.FC<TrickCardProps> = ({
   );
 };
 
-const Container = styled.div`
+const Container = styled.div<{ outlineColor: string }>`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -29,6 +33,7 @@ const Container = styled.div`
   margin: 0 5px;
   padding: 8px 10px;
   background-color: ${colors.lightTransparentGrey};
+  border: 2px solid ${({ outlineColor }) => outlineColor};
   border-radius: 7px;
 `;
 

--- a/src/ui/util/colors.ts
+++ b/src/ui/util/colors.ts
@@ -13,6 +13,7 @@ export const colors = {
   white: "#ffffff",
   black: "#000000",
   grey: "#aba8af",
+  lightgrey: "#eeeeee",
   wood: {
     light: "#deb887",
     medium: "#cdaa7d",

--- a/src/ui/util/colors.ts
+++ b/src/ui/util/colors.ts
@@ -14,6 +14,7 @@ export const colors = {
   black: "#000000",
   grey: "#aba8af",
   lightgrey: "#eeeeee",
+  lightTransparentGrey: "rgba(255, 255, 255, 0.3)",
   wood: {
     light: "#deb887",
     medium: "#cdaa7d",


### PR DESCRIPTION
resolves #51 

- add Box around played cards on table
- show box also for players who haven't played a card yet
- show boxes with bid number during bidding phase
- refactor PlayCard, add style for `undefined` cards, i.e. for the deck in the last round
- refactor `trick.cards` structure to objects instead of tuples
