### PR TITLE
Feature/tournament mode

### DIFF
--- a/src/game/WizardState.ts
+++ b/src/game/WizardState.ts
@@ -122,12 +122,12 @@ export function isSetRound(
  */
 export const generateDefaultWizardState = (
   ctx: Ctx,
+  setupData: WizardSetupData = {},
   {
     round: roundOptions,
     trick: trickOptions,
     ...options
-  }: Partial<WizardState> = {},
-  setupData: WizardSetupData = {}
+  }: Partial<WizardState> = {}
 ): WizardState => {
   const config = setupData.config ?? {};
   const numPlayers = ctx.numPlayers as NumPlayers;

--- a/src/game/WizardState.ts
+++ b/src/game/WizardState.ts
@@ -6,6 +6,7 @@ import { Phase } from "./phases/phase";
 import { ScorePad } from "./entities/score";
 import { Card, Suit } from "./entities/cards";
 import { OptionalTrickCard } from "./entities/trick";
+import { generateRounds } from "./entities/round.utils";
 
 /**
  * Describes the Wizard game state used in the g object.
@@ -19,7 +20,8 @@ export interface WizardState {
   // trick-specific state which is resetted after each trick
   trick: WizardTrickState | null;
   // general game state
-  numCards: number;
+  rounds: number[];
+  roundIndex: number;
   dealer: PlayerID;
   currentPlayer: PlayerID;
   scorePad: ScorePad;
@@ -125,7 +127,8 @@ export const generateDefaultWizardState = (
   const trick =
     trickOptions !== null ? generateBlankTrickState(trickOptions) : null;
   const defaultValues = {
-    numCards: 1,
+    roundIndex: 0,
+    rounds: generateRounds(numPlayers),
     dealer: -1 as PlayerID,
     scorePad: [],
     numPlayers,

--- a/src/game/WizardState.ts
+++ b/src/game/WizardState.ts
@@ -15,6 +15,7 @@ import { generateRounds } from "./entities/round.utils";
  * @interface WizardState
  */
 export interface WizardState {
+  config: WizardConfig;
   // round-specific state which is resetted after each round
   round: WizardRoundState | null;
   // trick-specific state which is resetted after each trick
@@ -27,6 +28,10 @@ export interface WizardState {
   scorePad: ScorePad;
   numPlayers: NumPlayers;
   phase: Phase;
+}
+
+export interface WizardConfig {
+  tournamentMode?: boolean;
 }
 
 /**
@@ -127,6 +132,7 @@ export const generateDefaultWizardState = (
   const trick =
     trickOptions !== null ? generateBlankTrickState(trickOptions) : null;
   const defaultValues = {
+    config: {},
     roundIndex: 0,
     rounds: generateRounds(numPlayers),
     dealer: -1 as PlayerID,

--- a/src/game/WizardState.ts
+++ b/src/game/WizardState.ts
@@ -140,7 +140,7 @@ export const generateDefaultWizardState = (
   const defaultValues = {
     config,
     roundIndex: 0,
-    rounds: generateRounds(numPlayers),
+    rounds: generateRounds(numPlayers, config.tournamentMode),
     dealer: -1 as PlayerID,
     scorePad: [],
     numPlayers,

--- a/src/game/WizardState.ts
+++ b/src/game/WizardState.ts
@@ -76,6 +76,10 @@ export interface Trump {
   suit?: Suit | null;
 }
 
+export interface WizardSetupData {
+  config?: WizardConfig;
+}
+
 /**
  * Checks if a trick is set.
  * Function uses typescript guards:
@@ -122,8 +126,10 @@ export const generateDefaultWizardState = (
     round: roundOptions,
     trick: trickOptions,
     ...options
-  }: Partial<WizardState> = {}
+  }: Partial<WizardState> = {},
+  setupData: WizardSetupData = {}
 ): WizardState => {
+  const config = setupData.config ?? {};
   const numPlayers = ctx.numPlayers as NumPlayers;
   const round =
     roundOptions !== null
@@ -132,7 +138,7 @@ export const generateDefaultWizardState = (
   const trick =
     trickOptions !== null ? generateBlankTrickState(trickOptions) : null;
   const defaultValues = {
-    config: {},
+    config,
     roundIndex: 0,
     rounds: generateRounds(numPlayers),
     dealer: -1 as PlayerID,

--- a/src/game/entities/round.utils.test.ts
+++ b/src/game/entities/round.utils.test.ts
@@ -1,0 +1,25 @@
+import { generateRounds } from "./round.utils";
+import { NumPlayers } from "./players";
+
+describe("generateRounds", () => {
+  test.each([3, 4, 5, 6])(
+    "tournament game with %i players has 10 rounds",
+    (numPlayers) => {
+      expect(generateRounds(numPlayers as NumPlayers, true)).toHaveLength(10);
+    }
+  );
+
+  test.each([
+    [3, 20],
+    [4, 15],
+    [5, 12],
+    [6, 10],
+  ])(
+    "non-tournament game with $i players has %i rounds",
+    (numPlayers, expectedNumRounds) => {
+      expect(generateRounds(numPlayers as NumPlayers)).toHaveLength(
+        expectedNumRounds
+      );
+    }
+  );
+});

--- a/src/game/entities/round.utils.ts
+++ b/src/game/entities/round.utils.ts
@@ -2,6 +2,25 @@ import range from "lodash/range";
 import { NumPlayers } from "./players";
 import { maxCards } from "./players.utils";
 
-export function generateRounds(numPlayers: NumPlayers): number[] {
-  return range(1, maxCards(numPlayers) + 1);
+export function generateRounds(
+  numPlayers: NumPlayers,
+  tournamentMode = false
+): number[] {
+  const fullRounds = range(1, maxCards(numPlayers) + 1);
+  if (!tournamentMode) {
+    return fullRounds;
+  }
+  switch (numPlayers) {
+    case 3:
+      return [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
+
+    case 4:
+      return [1, 3, 5, 7, 9, 11, 12, 13, 14, 15];
+
+    case 5:
+      return [2, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    case 6:
+    default:
+      return fullRounds;
+  }
 }

--- a/src/game/entities/round.utils.ts
+++ b/src/game/entities/round.utils.ts
@@ -1,0 +1,7 @@
+import range from "lodash/range";
+import { NumPlayers } from "./players";
+import { maxCards } from "./players.utils";
+
+export function generateRounds(numPlayers: NumPlayers): number[] {
+  return range(1, maxCards(numPlayers) + 1);
+}

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -4,13 +4,12 @@ import { generateDefaultWizardState, WizardState } from "./WizardState";
 import { setup } from "./phases/setup";
 import { bidding } from "./phases/bidding";
 import { playing } from "./phases/playing";
-import { maxCards } from "./entities/players.utils";
 import { Phase } from "./phases/phase";
 import { selectingTrump } from "./phases/selecting-trump";
 import { onBeginTurn } from "./turn";
 
-function endIf({ numCards, numPlayers }: WizardState): boolean {
-  return numCards > maxCards(numPlayers);
+function endIf({ roundIndex, rounds }: WizardState): boolean {
+  return roundIndex >= rounds.length;
 }
 
 function playerView(

--- a/src/game/phases/bidding.test.ts
+++ b/src/game/phases/bidding.test.ts
@@ -24,7 +24,8 @@ function generate({
     currentPlayer: currentPlayer.toString(),
   });
   const g: WizardState = {
-    numCards,
+    roundIndex: 0,
+    rounds: [numCards],
     scorePad: [],
     dealer: 0 as PlayerID,
     numPlayers,

--- a/src/game/phases/bidding.test.ts
+++ b/src/game/phases/bidding.test.ts
@@ -24,6 +24,7 @@ function generate({
     currentPlayer: currentPlayer.toString(),
   });
   const g: WizardState = {
+    config: {},
     roundIndex: 0,
     rounds: [numCards],
     scorePad: [],

--- a/src/game/phases/bidding.ts
+++ b/src/game/phases/bidding.ts
@@ -7,10 +7,11 @@ import { Phase } from "./phase";
 import { sortHand, getClientHand } from "../entities/cards.utils";
 
 export function bid(
-  { round, numCards, currentPlayer }: WizardState,
+  { round, roundIndex, rounds, currentPlayer }: WizardState,
   ctx: Ctx,
   numberOfTricks: number
 ): "INVALID_MOVE" | void {
+  const numCards = rounds[roundIndex];
   if (!isSetRound(round)) {
     throw new Error("round is not set");
   }
@@ -38,14 +39,17 @@ function endIf({ round }: WizardState): boolean {
   return !round.bids.includes(null);
 }
 
-function onEnd({ round, numCards }: WizardState): void {
+function onEnd({ round, roundIndex, rounds }: WizardState): void {
   if (!isSetRound(round)) {
     throw new Error("round is not set");
   }
   if (round.bids.includes(null)) {
     throw new Error("bids are not complete");
   }
-  round.bidsMismatch = getBidsMismatch(round.bids as number[], numCards);
+  round.bidsMismatch = getBidsMismatch(
+    round.bids as number[],
+    rounds[roundIndex]
+  );
 }
 
 export const bidding: PhaseConfig = {

--- a/src/game/phases/playing.ts
+++ b/src/game/phases/playing.ts
@@ -120,7 +120,7 @@ function endIf({ round }: WizardState): boolean {
 }
 
 function onEnd(g: WizardState): void {
-  const { round, numCards, scorePad } = g;
+  const { round, roundIndex, rounds, scorePad } = g;
   if (!isSetRound(round)) {
     throw new Error("round is not set");
   }
@@ -129,11 +129,16 @@ function onEnd(g: WizardState): void {
   }
 
   // calc score
-  g.scorePad = updateScorePad(round.bids, round.trickCount, numCards, scorePad);
+  g.scorePad = updateScorePad(
+    round.bids,
+    round.trickCount,
+    rounds[roundIndex],
+    scorePad
+  );
   // mark current round complete
   round.isComplete = true;
   // increment round
-  g.numCards = numCards + 1;
+  g.roundIndex += 1;
 }
 
 export const playing: PhaseConfig = {

--- a/src/game/phases/setup.test.ts
+++ b/src/game/phases/setup.test.ts
@@ -23,7 +23,7 @@ describe("handout", () => {
     handoutMove(g, ctx);
     g.round!.hands.forEach((hand) => {
       expect(hand).toBeInstanceOf(Array);
-      expect(hand.length).toBe(g.numCards);
+      expect(hand.length).toBe(g.rounds[g.roundIndex]);
     });
   });
 
@@ -32,7 +32,7 @@ describe("handout", () => {
     const g = generateDefaultWizardState(ctx);
 
     const expectedTrump = g.round!.deck[
-      g.round!.deck.length - g.numCards * ctx.numPlayers - 1
+      g.round!.deck.length - g.rounds[g.roundIndex] * ctx.numPlayers - 1
     ];
     handoutMove(g, ctx);
     expect(g.round!.trump.card).toBe(expectedTrump);
@@ -60,7 +60,8 @@ describe("handout", () => {
     testData.forEach(({ suit, rank }) => {
       const ctx = generateCtx();
       const g = generateDefaultWizardState(ctx);
-      const trumpIndex = g.round!.deck.length - g.numCards * ctx.numPlayers - 1;
+      const trumpIndex =
+        g.round!.deck.length - g.rounds[g.roundIndex] * ctx.numPlayers - 1;
       g.round!.deck[trumpIndex] = { suit, rank };
       handoutMove(g, ctx);
       expect(g.round!.trump.suit).toBe(suit);
@@ -70,7 +71,8 @@ describe("handout", () => {
   test("sets trumpSuit to undefined if trump card is a Z", () => {
     const ctx = generateCtx();
     const g = generateDefaultWizardState(ctx);
-    const trumpIndex = g.round!.deck.length - g.numCards * ctx.numPlayers - 1;
+    const trumpIndex =
+      g.round!.deck.length - g.rounds[g.roundIndex] * ctx.numPlayers - 1;
 
     g.round!.deck[trumpIndex] = { suit: Suit.Blue, rank: Rank.Z };
     handoutMove(g, ctx);
@@ -80,7 +82,8 @@ describe("handout", () => {
   test("calls selecting-trump phase when trump card is a Z", () => {
     const ctx = generateCtx();
     const g = generateDefaultWizardState(ctx);
-    const trumpIndex = g.round!.deck.length - g.numCards * ctx.numPlayers - 1;
+    const trumpIndex =
+      g.round!.deck.length - g.rounds[g.roundIndex] * ctx.numPlayers - 1;
 
     g.round!.deck[trumpIndex] = { suit: Suit.Blue, rank: Rank.Z };
     ctx.events!.setPhase = jest.fn();
@@ -91,7 +94,8 @@ describe("handout", () => {
   test("sets trumpSuit to null if turmp card is a N", () => {
     const ctx = generateCtx();
     const g = generateDefaultWizardState(ctx);
-    const trumpIndex = g.round!.deck.length - g.numCards * ctx.numPlayers - 1;
+    const trumpIndex =
+      g.round!.deck.length - g.rounds[g.roundIndex] * ctx.numPlayers - 1;
 
     g.round!.deck[trumpIndex] = { suit: Suit.Yellow, rank: Rank.N };
     handoutMove(g, ctx);
@@ -100,7 +104,7 @@ describe("handout", () => {
 
   test("sets trumpCard and trumpSuit to null in final round", () => {
     const ctx = generateCtx({ numPlayers: 4 });
-    const g = generateDefaultWizardState(ctx, { numCards: 15 });
+    const g = generateDefaultWizardState(ctx, { roundIndex: 14 });
     handoutMove(g, ctx);
     expect(g.round!.trump.card).toBeUndefined();
     expect(g.round!.trump.suit).toBeNull();
@@ -112,7 +116,7 @@ describe("handout", () => {
     const originalLength = g.round!.deck.length;
     handoutMove(g, ctx);
     expect(g.round!.deck.length).toBe(
-      originalLength - ctx.numPlayers * g.numCards - 1
+      originalLength - ctx.numPlayers * g.rounds[g.roundIndex] - 1
     );
   });
 
@@ -120,7 +124,7 @@ describe("handout", () => {
     const ctx = generateCtx();
     const g: WizardState = generateDefaultWizardState(ctx);
 
-    const cardsPlayer1 = range(0, g.numCards).map(
+    const cardsPlayer1 = range(0, g.rounds[g.roundIndex]).map(
       (cardI) =>
         g.round!.deck[g.round!.deck.length - 1 - ctx.numPlayers * cardI]
     );

--- a/src/game/phases/setup.test.ts
+++ b/src/game/phases/setup.test.ts
@@ -104,7 +104,7 @@ describe("handout", () => {
 
   test("sets trumpCard and trumpSuit to null in final round", () => {
     const ctx = generateCtx({ numPlayers: 4 });
-    const g = generateDefaultWizardState(ctx, { roundIndex: 14 });
+    const g = generateDefaultWizardState(ctx, {}, { roundIndex: 14 });
     handoutMove(g, ctx);
     expect(g.round!.trump.card).toBeUndefined();
     expect(g.round!.trump.suit).toBeNull();

--- a/src/game/phases/setup.ts
+++ b/src/game/phases/setup.ts
@@ -20,7 +20,7 @@ export function shuffleMove(wizardState: WizardState): void {
 }
 
 export function handoutMove(wizardState: WizardState, ctx: Ctx): void {
-  const { round, numCards, numPlayers, currentPlayer } = wizardState;
+  const { round, roundIndex, rounds, numPlayers, currentPlayer } = wizardState;
   if (!isSetRound(round)) {
     throw new Error("round is not set");
   }
@@ -32,7 +32,7 @@ export function handoutMove(wizardState: WizardState, ctx: Ctx): void {
 
   // handout cards to players
   const hands = new Array(numPlayers).fill(0).map<(Card | null)[]>(() => []);
-  new Array(numCards).fill(0).forEach(() => {
+  new Array(rounds[roundIndex]).fill(0).forEach(() => {
     players.forEach((player) => {
       const card = round.deck.pop();
 

--- a/src/ui/hooks/game-header-elements.tsx
+++ b/src/ui/hooks/game-header-elements.tsx
@@ -5,7 +5,7 @@ import { maxCards } from "../../game/entities/players.utils";
 
 export function useGameHeaderElements(): void {
   const {
-    wizardState: { numCards, numPlayers, round },
+    wizardState: { roundIndex, rounds, numPlayers, round },
   } = useGameState();
 
   // spacer
@@ -21,7 +21,7 @@ export function useGameHeaderElements(): void {
   useHeaderElement(
     "game-round",
     4,
-    `Runde ${numCards} / ${maxCards(numPlayers)}`
+    `Runde ${rounds[roundIndex]} / ${maxCards(numPlayers)}`
   );
 
   // bids mismatch

--- a/src/ui/lobby/CreateGame.tsx
+++ b/src/ui/lobby/CreateGame.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from "react";
 import { useHistory, Link as RouterLink } from "react-router-dom";
-import { Select, MenuItem, Button, Link } from "@material-ui/core";
+import {
+  Select,
+  MenuItem,
+  Button,
+  Link,
+  Checkbox,
+  FormControlLabel,
+} from "@material-ui/core";
 import styled from "styled-components";
 import { NumPlayers } from "../../game/entities/players";
 import { createGame } from "../services/api.service";
@@ -10,13 +17,18 @@ import { createdGameEventGA } from "../../analytics";
 export const CreateGame: React.FC = () => {
   const history = useHistory();
   const [numPlayers, setNumPlayers] = useState<NumPlayers>(3);
+  const [tournamentMode, setTournamentMode] = useState(false);
   return (
     <div>
       <h1>Starte ein Spiel</h1>
       <FormContainer>
         <Form
           onSubmit={async () => {
-            const gameID = await createGame(numPlayers);
+            const gameID = await createGame(numPlayers, {
+              config: {
+                tournamentMode,
+              },
+            });
             history.push(`/games/${gameID}`);
             createdGameEventGA(numPlayers);
           }}
@@ -35,6 +47,17 @@ export const CreateGame: React.FC = () => {
                 </MenuItem>
               ))}
             </StyledSelect>
+          </FieldContainer>
+          <FieldContainer>
+            <FormControlLabel
+              label="Wettbewerbs-Modus"
+              control={
+                <Checkbox
+                  checked={tournamentMode}
+                  onChange={(event) => setTournamentMode(event.target.checked)}
+                />
+              }
+            />
           </FieldContainer>
           <FieldContainer>
             <Button type="submit" color="primary" variant="contained">

--- a/src/ui/lobby/EnterGame.tsx
+++ b/src/ui/lobby/EnterGame.tsx
@@ -47,6 +47,20 @@ export const EnterGame: React.FC<EnterGameProps> = ({
     <div>
       <Card>
         <CardContent>
+          <h3>Spiel-Einstellungen</h3>
+          <ul>
+            <li>Anzahl Spieler: {game.players.length}</li>
+            <li>
+              Wettbewerbsmodus:{" "}
+              {game.setupData?.config?.tournamentMode ? "ein" : "aus"}
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+      <Spacer />
+
+      <Card>
+        <CardContent>
           <h3>Freunde einladen</h3>
           <p>Teile den Link um mit deinen Freunden zu spielen:</p>
           <TextField
@@ -83,6 +97,7 @@ export const EnterGame: React.FC<EnterGameProps> = ({
         </CardContent>
       </Card>
       <Spacer />
+
       <Card>
         <CardContent>
           <h3>

--- a/src/ui/player/actions/BiddingAction.tsx
+++ b/src/ui/player/actions/BiddingAction.tsx
@@ -8,9 +8,10 @@ import { isSetRound } from "../../../game/WizardState";
 
 export const BiddingAction: React.FC = () => {
   const {
-    wizardState: { numCards, currentPlayer, round },
+    wizardState: { roundIndex, rounds, currentPlayer, round },
     moves: { bid, sortCards },
   } = useGameState();
+  const numCards = rounds[roundIndex];
 
   if (!isSetRound(round)) {
     throw new Error("round is not set");

--- a/src/ui/score/ScorePad.tsx
+++ b/src/ui/score/ScorePad.tsx
@@ -16,7 +16,7 @@ import { CurrentRoundRow } from "./CurrentRoundRow";
 
 export const ScorePad: React.FC = () => {
   const {
-    wizardState: { scorePad, numCards, round },
+    wizardState: { scorePad, roundIndex, rounds, round },
     ctx: { numPlayers, gameover },
     gameMetadata,
   } = useGameState();
@@ -40,7 +40,7 @@ export const ScorePad: React.FC = () => {
             <ScoreRow numCards={n} playerScores={playerScores} key={n} />
           ))}
           {round && !round.isComplete && !gameover && (
-            <CurrentRoundRow numCards={numCards} bids={round.bids} />
+            <CurrentRoundRow numCards={rounds[roundIndex]} bids={round.bids} />
           )}
         </TableBody>
       </Table>

--- a/src/ui/services/api.service.ts
+++ b/src/ui/services/api.service.ts
@@ -11,7 +11,7 @@ export interface GameRoom {
   roomID?: GameID;
   gameID?: GameID;
   players: GameSeat[];
-  setupData?: unknown;
+  setupData?: WizardSetupData;
 }
 
 export interface GameSeat {

--- a/src/ui/services/api.service.ts
+++ b/src/ui/services/api.service.ts
@@ -1,6 +1,7 @@
 import { wizardGameConfig } from "../../game/game";
 import { PlayerID } from "../../game/entities/players";
 import { post, get } from "./fetch.service";
+import { WizardSetupData } from "../../game/WizardState";
 
 const { name, minPlayers, maxPlayers } = wizardGameConfig;
 
@@ -20,7 +21,7 @@ export interface GameSeat {
 
 export function createGame(
   numPlayers: number,
-  setupData?: unknown
+  setupData?: WizardSetupData
 ): Promise<GameID> {
   if (numPlayers < minPlayers || numPlayers > maxPlayers) {
     throw new Error(`invalid number of players ${numPlayers}`);

--- a/src/ui/table/BidRound.tsx
+++ b/src/ui/table/BidRound.tsx
@@ -12,7 +12,7 @@ import { colors } from "../util/colors";
 
 export const BidRound: React.FC = () => {
   const {
-    wizardState: { numPlayers, dealer, round, numCards },
+    wizardState: { numPlayers, dealer, round, roundIndex, rounds },
     gameMetadata,
   } = useGameState();
 
@@ -38,7 +38,7 @@ export const BidRound: React.FC = () => {
       <TrickCardBox player="TOTAL">
         <TotalBox>
           <h2>
-            {totalBids} von {numCards}
+            {totalBids} von {rounds[roundIndex]}
           </h2>
         </TotalBox>
       </TrickCardBox>


### PR DESCRIPTION
resolves #41 resolves #122 

Changes:
- add `rounds` array to wizard state storing the number of cards for each round played
- add `roundIndex` to wizard state storing the current round's index in `rounds`
- remove the `numCards` field from the wizard state
- add `config` object to the wizard state to store the setupData
- send `setupData` to the `createGame` api containing the tournament mode flag
- add checkbox for tournament mode to the `CreateGame` component