### PR TITLE
use strict undefined check on playerID

### DIFF
--- a/src/ui/lobby/PlayGame.tsx
+++ b/src/ui/lobby/PlayGame.tsx
@@ -23,7 +23,7 @@ export const PlayGame: React.FC<PlayGameProps> = ({
   }, [playerID]);
   return (
     <>
-      {(!playerID || !credentials) && (
+      {(playerID === undefined || !credentials) && (
         <AppBar position="static" color="transparent">
           <Toolbar variant="dense">
             <i>Zuschauer-Modus</i>


### PR DESCRIPTION
fixes #125 
- use strict `playerID === undefined` instead of `!playerID` to check if client is spectator or player