### PR TITLE
fix change in sorting issue

### DIFF
--- a/src/game/WizardState.ts
+++ b/src/game/WizardState.ts
@@ -3,7 +3,7 @@ import { generateCardDeck } from "./entities/cards.utils";
 import { NumPlayers, PlayerID } from "./entities/players";
 import { Phase } from "./phases/phase";
 import { ScorePad } from "./entities/score";
-import { Card, Suit } from "./entities/cards";
+import { Card, Suit, Rank } from "./entities/cards";
 import { OptionalTrickCard, TrickCard } from "./entities/trick";
 import { generateRounds } from "./entities/round.utils";
 
@@ -56,12 +56,23 @@ export interface WizardRoundState {
   bids: (number | null)[];
   bidsMismatch?: number;
   hands: (Card | null)[][];
+  handsMeta: (HandMeta | null)[];
   trickCount: number[];
   trump: Trump;
   deck: (Card | null)[];
   previousTrick?: TrickCard[];
   isComplete?: boolean;
 }
+
+export type HandMeta = {
+  total: number;
+  suits: {
+    [suit in Suit]: number;
+  };
+  ranks: {
+    [rank in Rank]: number;
+  };
+};
 
 /**
  * Describes the round's trump suit.
@@ -171,6 +182,7 @@ export function generateBlankRoundState(
   const defaultValues = {
     bids: new Array(numPlayers).fill(null),
     hands: new Array(numPlayers).fill([]),
+    handsMeta: new Array(numPlayers).fill(null),
     trickCount: new Array(numPlayers).fill(null),
     trump: { card: null },
     deck: ctx.random!.Shuffle(generateCardDeck()),

--- a/src/game/entities/cards.ts
+++ b/src/game/entities/cards.ts
@@ -46,8 +46,8 @@ export const regularRanks = [
   Rank.Eleven,
   Rank.Twelve,
   Rank.Thirteen,
-];
-export const specialRanks = [Rank.N, Rank.Z];
+] as const;
+export const specialRanks = [Rank.N, Rank.Z] as const;
 export const allRanks = [...regularRanks, ...specialRanks];
 
 export interface Card {

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -22,7 +22,7 @@ function playerView(
   // no changes if no round is set
   if (!wizardState.round) return wizardState;
   const {
-    round: { deck, hands },
+    round: { deck, hands, handsMeta },
     round,
   } = wizardState;
 
@@ -37,6 +37,11 @@ function playerView(
         // keep client's hand
         if (index.toString() === playerID) return hand;
         return hand.map(() => null);
+      }),
+      handsMeta: handsMeta.map((hand, index) => {
+        // keep client's hand
+        if (index.toString() === playerID) return hand;
+        return null;
       }),
     },
   };

--- a/src/game/mock-state.tsx
+++ b/src/game/mock-state.tsx
@@ -1,3 +1,5 @@
+import { Suit } from "./entities/cards";
+
 export const scenarioFinalState = {
   config: {},
   roundIndex: 14,
@@ -921,6 +923,20 @@ export const mockStateExample = {
           rank: 9,
         },
       ],
+    ],
+    handsMeta: [
+      null,
+      null,
+      null,
+      {
+        total: 15,
+        suits: {
+          [Suit.Blue]: 0,
+          [Suit.Green]: 0,
+          [Suit.Red]: 0,
+          [Suit.Yellow]: 0,
+        },
+      },
     ],
     trickCount: [4, 3, 3, 4],
     trump: {

--- a/src/game/phases/bidding.test.ts
+++ b/src/game/phases/bidding.test.ts
@@ -35,6 +35,7 @@ function generate({
     round: {
       bids,
       hands: new Array(ctx.numPlayers).fill(null),
+      handsMeta: new Array(ctx.numPlayers).fill(null),
       deck: [],
       trump: { card: null },
       trickCount: new Array(ctx.numPlayers).fill(0),

--- a/src/game/phases/playing.test.ts
+++ b/src/game/phases/playing.test.ts
@@ -40,6 +40,7 @@ function generate({
     round: {
       bids: new Array(ctx.numPlayers).fill(0),
       hands,
+      handsMeta: new Array(ctx.numPlayers).fill(null),
       deck: [],
       trump: { card: null },
       trickCount: new Array(ctx.numPlayers).fill(0),

--- a/src/game/phases/setup.ts
+++ b/src/game/phases/setup.ts
@@ -1,13 +1,15 @@
 /* eslint-disable no-param-reassign */
 import { PhaseConfig, Ctx } from "boardgame.io";
 
+import { fromPairs } from "lodash";
 import {
   WizardState,
   isSetRound,
   generateBlankRoundState,
+  HandMeta,
 } from "../WizardState";
 import { playersRound } from "../entities/players.utils";
-import { Card, Rank, Suit } from "../entities/cards";
+import { Card, Rank, Suit, allSuits, allRanks } from "../entities/cards";
 import { Phase } from "./phase";
 import { onBeginTurn } from "../turn";
 import { NumPlayers, PlayerID } from "../entities/players";
@@ -39,6 +41,33 @@ export function handoutMove(wizardState: WizardState, ctx: Ctx): void {
     });
   });
   round.hands = hands;
+
+  // create hand meta data
+  const handsMeta = hands.map((hand) => {
+    const suits = fromPairs(
+      allSuits.map((suit) => {
+        const cardsOfSuit = hand.filter(
+          (card) =>
+            card?.suit === suit &&
+            card?.rank !== Rank.N &&
+            card?.rank !== Rank.Z
+        );
+        return [suit, cardsOfSuit.length];
+      })
+    );
+    const ranks = fromPairs(
+      allRanks.map((rank) => {
+        const cardsOfRank = hand.filter((card) => card?.rank === rank);
+        return [rank, cardsOfRank.length];
+      })
+    );
+    return {
+      total: hand.length,
+      suits,
+      ranks,
+    } as HandMeta;
+  });
+  round.handsMeta = handsMeta;
 
   // draw trump card
   let trumpCard: Card | undefined;

--- a/src/ui/player/ClientHand.tsx
+++ b/src/ui/player/ClientHand.tsx
@@ -2,16 +2,18 @@ import React, { useMemo } from "react";
 import styled from "styled-components";
 import { playableCardsInHand } from "../../game/entities/cards.utils";
 import { PlayCard } from "../components/playcard/PlayCard";
-import { Card } from "../../game/entities/cards";
+import { Card, Suit } from "../../game/entities/cards";
 import { useProfile } from "../ProfileProvider";
 import { sortHand } from "../util/sort-hands";
-import { useGameState } from "../GameContext";
+import { HandMeta } from "../../game/WizardState";
 
 export interface HandCardsProps {
-  cards: (Card | null)[];
+  cards: Card[];
   isInteractive: boolean;
   onClickCard?: (cardIndex: number) => void;
   lead?: Card;
+  trumpSuit: Suit | null | undefined;
+  handMeta: HandMeta;
 }
 
 export const ClientHand: React.FC<HandCardsProps> = ({
@@ -19,19 +21,18 @@ export const ClientHand: React.FC<HandCardsProps> = ({
   isInteractive,
   onClickCard = () => {},
   lead,
+  trumpSuit,
+  handMeta,
 }) => {
-  const playableCards =
-    isInteractive && !cards.includes(null)
-      ? playableCardsInHand(cards as Card[], lead)
-      : undefined;
+  const playableCards = isInteractive
+    ? playableCardsInHand(cards as Card[], lead)
+    : undefined;
 
-  const { wizardState } = useGameState();
-  const suit = wizardState?.round?.trump?.suit;
   const { preferences } = useProfile();
   const { handOrder } = preferences;
   const sortedCards = useMemo(
-    () => sortHand(cards as Card[], suit, handOrder),
-    [cards, suit, handOrder]
+    () => sortHand(cards, trumpSuit, handMeta, handOrder),
+    [cards, trumpSuit, handMeta, handOrder]
   );
 
   function getIndex(card: Card): number {

--- a/src/ui/player/Player.tsx
+++ b/src/ui/player/Player.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Card, CardContent } from "@material-ui/core";
+import { Card as MatCard, CardContent } from "@material-ui/core";
 import styled from "styled-components";
 
 import { Phase } from "../../game/phases/phase";
@@ -10,6 +10,8 @@ import { Header } from "./Header";
 import { colors } from "../util/colors";
 import { PlayerProps } from "./Player.props";
 import { OpponentHand } from "./OpponentHand";
+import { Card } from "../../game/entities/cards";
+import { HandMeta } from "../../game/WizardState";
 
 export const Player: React.FC<PlayerProps> = ({ playerID }) => {
   const {
@@ -30,10 +32,12 @@ export const Player: React.FC<PlayerProps> = ({ playerID }) => {
             {round &&
               (isClient ? (
                 <ClientHand
-                  cards={round.hands[clientID]}
+                  cards={round.hands[clientID] as Card[]}
                   isInteractive={isTurn && phase === Phase.Playing}
                   onClickCard={(i) => play(i)}
                   lead={trick?.isComplete ? undefined : trick?.lead}
+                  trumpSuit={round.trump.suit}
+                  handMeta={round.handsMeta[clientID] as HandMeta}
                 />
               ) : (
                 <OpponentHand numCards={round.hands[playerID].length} />
@@ -45,7 +49,7 @@ export const Player: React.FC<PlayerProps> = ({ playerID }) => {
   );
 };
 
-const StyledCard = styled(Card)`
+const StyledCard = styled(MatCard)`
   flex-grow: 1;
   display: flex;
 `;

--- a/src/ui/util/sort-hands.ts
+++ b/src/ui/util/sort-hands.ts
@@ -2,6 +2,7 @@ import flatten from "lodash/flatten";
 import groupBy from "lodash/groupBy";
 import { Card, Rank, Suit } from "../../game/entities/cards";
 import { HandOrderPreference } from "../services/profile.service";
+import { HandMeta } from "../../game/WizardState";
 
 /**
  * sorts the cards in a hand by the following scheme:
@@ -17,7 +18,8 @@ import { HandOrderPreference } from "../services/profile.service";
  */
 export function sortHand(
   hand: Card[],
-  trumpSuit?: Suit | null,
+  trumpSuit: Suit | null | undefined,
+  handMeta: HandMeta,
   handOrderPreference?: HandOrderPreference | null
 ): Card[] {
   if (
@@ -34,15 +36,15 @@ export function sortHand(
 
   const sortedGroups = Object.entries(groupedHand)
     // sort groups in this order: [Ns, ... non-trump suits sorted by num card, trump suit, Zs]
-    .sort(([keyA, cardsA], [keyB, cardsB]) => {
+    .sort(([keyA], [keyB]) => {
       // always sort N left and Z right
       if (keyA === Rank.N.toString() || keyB === Rank.Z.toString()) return -1;
       if (keyA === Rank.Z.toString() || keyB === Rank.N.toString()) return 1;
       // always sort trump beside Z
       if (keyA === trumpSuit) return 1;
       if (keyB === trumpSuit) return -1;
-      // sort by number of cards of color
-      return cardsA.length - cardsB.length;
+      // sort by number of cards of suit (in the original hand)
+      return handMeta.suits[keyA as Suit] - handMeta.suits[keyB as Suit];
     })
     // sort cards in each group by rank
     .map(([, cardGroup]) => cardGroup.sort((a, b) => a.rank - b.rank));


### PR DESCRIPTION
Changes:

- prevent change in hand sorting order during game
- add a new `handsMeta` field to the wizard state containing meta info on each player's number of cards by suit and rank.
- calculate handsMeta data in setup move after handout
- use handsMeta values in UI sorting function instead of values from current hand to sort the suits