### PR TITLE
hotfix: add ssl options to postgres constructor

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,15 @@ Sentry.init({ dsn: process.env.SENTRY_SERVER_DSN });
 
 let db: StorageCache | undefined;
 if (process.env.DATABASE_URL) {
-  const postgres = new PostgresStore(process.env.DATABASE_URL!);
+  const postgres = new PostgresStore(process.env.DATABASE_URL!, {
+    // fix SSL error https://stackoverflow.com/a/64960461
+    dialectOptions: {
+      ssl: {
+        require: true,
+        rejectUnauthorized: false,
+      },
+    },
+  });
   db = new StorageCache(postgres);
   console.log("using postgresql storage");
 } else {


### PR DESCRIPTION
production node server was crashing because [heroku started to enforce SSL connection to postgres db](https://devcenter.heroku.com/changelog-items/2035).

add ssl options to sequelize constructor to fix